### PR TITLE
Lesson5/retain cycle async loading search delay fixes

### DIFF
--- a/Podcast/Podcast/API/APIService.swift
+++ b/Podcast/Podcast/API/APIService.swift
@@ -21,20 +21,20 @@ class APIService {
         let secureFeedUrl = feedUrl.contains("https") ? feedUrl : feedUrl.replacingOccurrences(of: "http", with: "https")
         
         guard let url = URL(string: secureFeedUrl) else { return }
-        let parser = FeedParser(URL: url)
-        parser?.parseAsync(result: { (result) in
-        print("Successfully parse feed:", result.isSuccess)
         
-        if let err = result.error {
-        print("Failed to parse XML Feed:" , err)
-        return
+        DispatchQueue.global(qos: .background).async {
+            let parser = FeedParser(URL: url)
+            parser?.parseAsync(result: { (result) in
+                print("Successfully parse feed:", result.isSuccess)
+                if let err = result.error {
+                    print("Failed to parse XML Feed:" , err)
+                    return
+                }
+                guard let feed = result.rssFeed else { return }
+                let episodes = feed.toEpisodes()
+                completionHandler(episodes)
+            })
         }
-        
-        guard let feed = result.rssFeed else { return }
-        let episodes = feed.toEpisodes()
-        completionHandler(episodes)
-
-        })
     }
     
     func fetchPodcasts(searchText: String, completionHandler: @escaping ([Podcast]) -> ()) {

--- a/Podcast/Podcast/Controllers/EpisodesController.swift
+++ b/Podcast/Podcast/Controllers/EpisodesController.swift
@@ -50,6 +50,17 @@ class EpisodesController: UITableViewController {
     
     //MARK:- UITableView
     
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let activityIndicatorView = UIActivityIndicatorView(style: .whiteLarge)
+        activityIndicatorView.color =  .darkGray
+        activityIndicatorView.startAnimating()
+        return activityIndicatorView
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return episodes.isEmpty ? 200:0
+    }
+    
     override  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let episode = self.episodes[indexPath.row]
         print("Trying to play episode:", episode.title)

--- a/Podcast/Podcast/Controllers/PodcastsSearchController.swift
+++ b/Podcast/Podcast/Controllers/PodcastsSearchController.swift
@@ -37,13 +37,17 @@ class PodcastsSearchController: UITableViewController, UISearchBarDelegate {
         searchController.searchBar.delegate = self
     }
     
+    var timer: Timer?
+    
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        APIService.shared.fetchPodcasts(searchText: searchText) { (podcasts) in
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false, block: { (timer) in
+            APIService.shared.fetchPodcasts(searchText: searchText) { (podcasts) in
+                self.podcasts = podcasts
+                self.tableView.reloadData()
+            }
+        })
         
-        self.podcasts = podcasts
-        self.tableView.reloadData()
-            
-        }
     }
     
     fileprivate func setupTableView() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -40,12 +40,11 @@ class PlayerDetailsView: UIView {
     
     fileprivate func observePlayerCurrentTime() {
         let interval = CMTime(value: 1, timescale: 2)
-        player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { (time) in
-        self.currentTimeLabel.text = time.toDisplayString()
-        let durationTime = self.player.currentItem?.duration
-        self.durationLabel.text = durationTime?.toDisplayString()
-        self.updateCurrentTimeSlider()
-        
+        player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self](time) in
+        self?.currentTimeLabel.text = time.toDisplayString()
+        let durationTime = self?.player.currentItem?.duration
+        self?.durationLabel.text = durationTime?.toDisplayString()
+        self?.updateCurrentTimeSlider()
         }
     }
     
@@ -64,8 +63,9 @@ class PlayerDetailsView: UIView {
         let time = CMTimeMake(value: 1, timescale: 3)
         let times = [NSValue(time: time)]
         player.addBoundaryTimeObserver(forTimes: times, queue: .main) {
+            [weak self] in
             print("Episode started playing")
-            self.enlargeEpisodeImageView()
+            self? .enlargeEpisodeImageView()
         }
     }
     


### PR DESCRIPTION
Fix retain cycle on addBoundaryTimeObserver and addPeriodicTimeObserver methods inside PlayerDetailsView by making the 'self' reference 'weak'.
Removed the delay in loading the episode by loading the episode Asynchronously inside the APIService.
Create a 0.5 second delay in textDidChange method by creating a timer inside PodcastsSearchController to minimize the cellular data usage and make the search function less aggressive.
