### PR TITLE
Lesson7/dismissondrag

### DIFF
--- a/Podcast/Podcast.xcodeproj/project.pbxproj
+++ b/Podcast/Podcast.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		FC46D6262322CBB300173BBD /* Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC46D6252322CBB300173BBD /* Episode.swift */; };
 		FC46D62D2322CE5200173BBD /* EpisodeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC46D62B2322CE5200173BBD /* EpisodeCell.swift */; };
 		FC46D62E2322CE5200173BBD /* EpisodeCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC46D62C2322CE5200173BBD /* EpisodeCell.xib */; };
+		FC6B1C8524349E5600235743 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6B1C8424349E5600235743 /* UIApplication.swift */; };
 		FC6C851E230869CE00444565 /* PodcastsSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C851D230869CE00444565 /* PodcastsSearchController.swift */; };
 		FC6C85212308707A00444565 /* Podcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C85202308707A00444565 /* Podcast.swift */; };
 		FC8976EE2326A5AE001F90BA /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8976ED2326A5AD001F90BA /* String.swift */; };
@@ -47,6 +48,7 @@
 		FC46D6252322CBB300173BBD /* Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Episode.swift; sourceTree = "<group>"; };
 		FC46D62B2322CE5200173BBD /* EpisodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeCell.swift; sourceTree = "<group>"; };
 		FC46D62C2322CE5200173BBD /* EpisodeCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EpisodeCell.xib; sourceTree = "<group>"; };
+		FC6B1C8424349E5600235743 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
 		FC6C851D230869CE00444565 /* PodcastsSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastsSearchController.swift; sourceTree = "<group>"; };
 		FC6C85202308707A00444565 /* Podcast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Podcast.swift; sourceTree = "<group>"; };
 		FC8976ED2326A5AD001F90BA /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				FC8976ED2326A5AD001F90BA /* String.swift */,
 				FC8976EF2326AD55001F90BA /* RSSFeed.swift */,
 				FC46593E23772021008D5C0F /* CMTime.swift */,
+				FC6B1C8424349E5600235743 /* UIApplication.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 				FC8976F02326AD55001F90BA /* RSSFeed.swift in Sources */,
 				FCAD1CF8232EA03F009B7C79 /* PlayerDetailsView.swift in Sources */,
 				FC6C851E230869CE00444565 /* PodcastsSearchController.swift in Sources */,
+				FC6B1C8524349E5600235743 /* UIApplication.swift in Sources */,
 				FC8976EE2326A5AE001F90BA /* String.swift in Sources */,
 				FC46593F23772021008D5C0F /* CMTime.swift in Sources */,
 				FC2D32AB2301B45F00C415D9 /* ViewController.swift in Sources */,

--- a/Podcast/Podcast/Extensions/UIApplication.swift
+++ b/Podcast/Podcast/Extensions/UIApplication.swift
@@ -1,0 +1,16 @@
+//
+//  UIApplication.swift
+//  Podcast
+//
+//  Created by Jaycell on 4/1/20.
+//  Copyright © 2020 Jaycell. All rights reserved.
+//
+
+import UIKit
+
+extension UIApplication {
+    static func mainTabBarController() -> MainTabBarController? {
+//        UIApplication.shared.keyWindow?.rootViewController as? MainTabBarController
+        return shared.keyWindow?.rootViewController as? MainTabBarController
+    }
+}

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -63,6 +63,12 @@ class PlayerDetailsView: UIView {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapMaximize)))
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
         miniPlayerView.addGestureRecognizer(panGesture)
+        
+        maximizedStackView.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handleDismissalPan)))
+    }
+    
+    @objc func handleDismissalPan(gesture: UIPanGestureRecognizer) {
+        print("MaximizedStackView Dismissial")
     }
     
     override func awakeFromNib() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -72,6 +72,10 @@ class PlayerDetailsView: UIView {
         if gesture.state == .changed {
             let translation = gesture.translation(in: superview)
             maximizedStackView.transform = CGAffineTransform(translationX: 0, y: translation.y)
+        } else if gesture.state == .ended {
+            UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
+                self.maximizedStackView.transform = .identity
+            })
         }
     }
     

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -59,12 +59,16 @@ class PlayerDetailsView: UIView {
     
     var panGesture: UIPanGestureRecognizer!
     
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        
+    fileprivate func setupGestures() {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapMaximize)))
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
         addGestureRecognizer(panGesture)
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        setupGestures()
         
         observePlayerCurrentTime()
         

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -69,6 +69,10 @@ class PlayerDetailsView: UIView {
     
     @objc func handleDismissalPan(gesture: UIPanGestureRecognizer) {
         print("MaximizedStackView Dismissial")
+        if gesture.state == .changed {
+            let translation = gesture.translation(in: superview)
+            maximizedStackView.transform = CGAffineTransform(translationX: 0, y: translation.y)
+        }
     }
     
     override func awakeFromNib() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -62,7 +62,7 @@ class PlayerDetailsView: UIView {
     fileprivate func setupGestures() {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapMaximize)))
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
-        addGestureRecognizer(panGesture)
+        miniPlayerView.addGestureRecognizer(panGesture)
     }
     
     override func awakeFromNib() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -124,9 +124,7 @@ class PlayerDetailsView: UIView {
         UIView.animate(withDuration: 0.5 , delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
             self.transform = .identity
             if translation.y < -200 || velocity.y < -500 {
-                let mainTabBarController = UIApplication.shared.keyWindow?.rootViewController as? MainTabBarController
-                mainTabBarController?.maximizePlayerDetails(episode: nil)
-                gesture.isEnabled = false
+                UIApplication.mainTabBarController()?.maximizePlayerDetails(episode: nil)
             } else {
                 self.miniPlayerView.alpha = 1
                 self.maximizedStackView.alpha = 0
@@ -134,10 +132,8 @@ class PlayerDetailsView: UIView {
         })
     }
     
-    @objc func handleTapMaximize() {
-        let mainTabBarController = UIApplication.shared.keyWindow?.rootViewController as? MainTabBarController
-        mainTabBarController?.maximizePlayerDetails(episode: nil )
-        panGesture.isEnabled = false
+    @objc func handleTapMaximize() { 
+        UIApplication.mainTabBarController()?.maximizePlayerDetails(episode: nil )
     }
     
     static func initFromNib() -> PlayerDetailsView {
@@ -199,7 +195,6 @@ class PlayerDetailsView: UIView {
     @IBAction func handleDismiss(_ sender: Any) {
         let mainTabBarController = UIApplication.shared.keyWindow?.rootViewController as? MainTabBarController
         mainTabBarController?.minimizePlayerDetails()
-        panGesture.isEnabled = true
     }
     
     fileprivate func enlargeEpisodeImageView() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -73,8 +73,14 @@ class PlayerDetailsView: UIView {
             let translation = gesture.translation(in: superview)
             maximizedStackView.transform = CGAffineTransform(translationX: 0, y: translation.y)
         } else if gesture.state == .ended {
+            let translation = gesture.translation(in: superview)
             UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 1, options: .curveEaseOut, animations: {
                 self.maximizedStackView.transform = .identity
+                
+                if translation.y > 50 {
+                    let mainTabBarController = UIApplication.shared.keyWindow?.rootViewController as? MainTabBarController
+                    mainTabBarController?.minimizePlayerDetails()
+                }
             })
         }
     }


### PR DESCRIPTION
Refactor codes for gestures.
Removed bug where in the panning gesture occurs on maximized player by adding the panGesture to miniPlayerView. The gesture will only work on the miniPlayerView.
Then, created a gesture recognizer inside the maximizedStackView to monitor the panning gesture inside the maximized player view, and by translating the gesture's y axis, create a condition that if the y translation value exceeds 50, the player will be minimized.
Lastly, refactor the access MainTabBarController by creating an extension file. Now, the the extension only has to be called instead of defining everytime it was needed.