### PR TITLE
Lesson8/bg audio command center

### DIFF
--- a/Podcast/Podcast.xcodeproj/project.pbxproj
+++ b/Podcast/Podcast.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		48B0BAB10C72DAC2A9E10DF2 /* Pods_Podcast.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Podcast.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6EE334FA2ECF319C14CD4F2 /* Pods-Podcast.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Podcast.debug.xcconfig"; path = "Target Support Files/Pods-Podcast/Pods-Podcast.debug.xcconfig"; sourceTree = "<group>"; };
 		FC0A2141231D694000ECCA3E /* EpisodesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodesController.swift; sourceTree = "<group>"; };
-		FC2D32A52301B45F00C415D9 /* Podcast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Podcast.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC2D32A52301B45F00C415D9 /*  .app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = " .app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC2D32A82301B45F00C415D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FC2D32AA2301B45F00C415D9 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		FC2D32AD2301B45F00C415D9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -102,7 +102,7 @@
 		FC2D32A62301B45F00C415D9 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FC2D32A52301B45F00C415D9 /* Podcast.app */,
+				FC2D32A52301B45F00C415D9 /*  .app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -179,9 +179,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		FC2D32A42301B45F00C415D9 /* Podcast */ = {
+		FC2D32A42301B45F00C415D9 /*   */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = FC2D32B72301B46100C415D9 /* Build configuration list for PBXNativeTarget "Podcast" */;
+			buildConfigurationList = FC2D32B72301B46100C415D9 /* Build configuration list for PBXNativeTarget " " */;
 			buildPhases = (
 				EF2762C9EF0FD3C36195D8F6 /* [CP] Check Pods Manifest.lock */,
 				FC2D32A12301B45F00C415D9 /* Sources */,
@@ -193,9 +193,9 @@
 			);
 			dependencies = (
 			);
-			name = Podcast;
+			name = " ";
 			productName = Podcast;
-			productReference = FC2D32A52301B45F00C415D9 /* Podcast.app */;
+			productReference = FC2D32A52301B45F00C415D9 /*  .app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -210,6 +210,11 @@
 				TargetAttributes = {
 					FC2D32A42301B45F00C415D9 = {
 						CreatedOnToolsVersion = 10.3;
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -226,7 +231,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				FC2D32A42301B45F00C415D9 /* Podcast */,
+				FC2D32A42301B45F00C415D9 /*   */,
 			);
 		};
 /* End PBXProject section */
@@ -500,7 +505,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FC2D32B72301B46100C415D9 /* Build configuration list for PBXNativeTarget "Podcast" */ = {
+		FC2D32B72301B46100C415D9 /* Build configuration list for PBXNativeTarget " " */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				FC2D32B82301B46100C415D9 /* Debug */,

--- a/Podcast/Podcast.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Podcast/Podcast.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Podcast/Podcast/Info.plist
+++ b/Podcast/Podcast/Info.plist
@@ -2,21 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>mzstatic.com</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -35,6 +20,25 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>mzstatic.com</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import AVKit
+import MediaPlayer
 
 class PlayerDetailsView: UIView {
     
@@ -95,8 +96,28 @@ class PlayerDetailsView: UIView {
         
     }
     
+    fileprivate func setupRemoteCOntrol() {
+        UIApplication.shared.beginReceivingRemoteControlEvents()
+        let commandCenter = MPRemoteCommandCenter.shared()
+        
+        commandCenter.playCommand.isEnabled = true
+        commandCenter.playCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
+            print("Should play podcast...")
+            
+        return .success
+        }
+        
+        commandCenter.pauseCommand.isEnabled = true
+        commandCenter.pauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
+            print("Should pause podcast...")
+            return .success
+        }
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
+        
+        setupRemoteCOntrol()
         
         setupAudioSession()
         

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -102,14 +102,17 @@ class PlayerDetailsView: UIView {
         
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-            print("Should play podcast...")
+            
+            self.player.play()
             
         return .success
         }
         
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-            print("Should pause podcast...")
+            
+            self.player.pause()
+            
             return .success
         }
     }

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -101,23 +101,34 @@ class PlayerDetailsView: UIView {
         let commandCenter = MPRemoteCommandCenter.shared()
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-        self.player.play()
+            self.player.play()
             
-        self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
-        self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
+            self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
+            self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             
         return .success
         }
         
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-        self.player.pause()
+            self.player.pause()
             
-        self.playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
-        self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
+            self.playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
+            self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
+
+            return .success
+        }
+        
+        commandCenter.togglePlayPauseCommand.isEnabled = true
+        commandCenter.togglePlayPauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
             
-            
-        return .success
+            self.handlePlayPause()
+//            if self.player.timeControlStatus == .playing {
+//                self.player.pause()
+//            } else {
+//                self.player.play()
+//            }
+            return .success
         }
     }
     

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -99,21 +99,25 @@ class PlayerDetailsView: UIView {
     fileprivate func setupRemoteCOntrol() {
         UIApplication.shared.beginReceivingRemoteControlEvents()
         let commandCenter = MPRemoteCommandCenter.shared()
-        
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
+        self.player.play()
             
-            self.player.play()
+        self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
+        self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             
         return .success
         }
         
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
+        self.player.pause()
             
-            self.player.pause()
+        self.playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
+        self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             
-            return .success
+            
+        return .success
         }
     }
     

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -106,7 +106,7 @@ class PlayerDetailsView: UIView {
             self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             
-        return .success
+            return .success
         }
         
         commandCenter.pauseCommand.isEnabled = true

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -85,8 +85,20 @@ class PlayerDetailsView: UIView {
         }
     }
     
+    fileprivate func setupAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch let sessionErr {
+            print("Failed to activate session:", sessionErr)
+        }
+        
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
+        
+        setupAudioSession()
         
         setupGestures()
         


### PR DESCRIPTION
Setup code to play the podcast in the background. Imported MediaPlayer library to access control of media player in control center. Used MPRemoteCommandCenter to give the podcast app control over the play/pause button. Lastly, matched the button image with the current state of the episode player buttons.