### PR TITLE
Lesson8/artworkelapsedtimefixes

### DIFF
--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -74,26 +74,26 @@ class PlayerDetailsView: UIView {
         let durationTime = self?.player.currentItem?.duration
         self?.durationLabel.text = durationTime?.toDisplayString()
             
-        self? .setupLockscreenCurrentTime()
+//        self? .setupLockscreenCurrentTime()
             
         self?.updateCurrentTimeSlider()
         }
     }
     
-    fileprivate func setupLockscreenCurrentTime() {
-        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
-        
-        // modify here
-        guard let currentItem = player.currentItem else { return }
-        let durationInSeconds = CMTimeGetSeconds(currentItem.duration)
-        
-        let elapsedTIme = CMTimeGetSeconds(player.currentTime())
-        
-        nowPlayingInfo? [MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsedTIme
-        nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = durationInSeconds
-        
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-    }
+//    fileprivate func setupLockscreenCurrentTime() {
+//        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
+//
+//        // modify here
+//        guard let currentItem = player.currentItem else { return }
+//        let durationInSeconds = CMTimeGetSeconds(currentItem.duration)
+//
+//        let elapsedTIme = CMTimeGetSeconds(player.currentTime())
+//
+//        nowPlayingInfo? [MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsedTIme
+//        nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = durationInSeconds
+//
+//        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+//    }
     
     fileprivate func updateCurrentTimeSlider() {
         let currentTimeSeconds = CMTimeGetSeconds(player.currentTime())

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -254,6 +254,8 @@ class PlayerDetailsView: UIView {
         let seekTimeInSeconds = Float64(percentage) * durationInSeconds
         let seekTime = CMTimeMakeWithSeconds(seekTimeInSeconds, preferredTimescale: Int32(1))
         
+        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = seekTimeInSeconds
+        
         player.seek(to: seekTime)
     }
     @IBAction func handleFastForward(_ sender: Any) {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -74,26 +74,9 @@ class PlayerDetailsView: UIView {
         let durationTime = self?.player.currentItem?.duration
         self?.durationLabel.text = durationTime?.toDisplayString()
             
-//        self? .setupLockscreenCurrentTime()
-            
         self?.updateCurrentTimeSlider()
         }
     }
-    
-//    fileprivate func setupLockscreenCurrentTime() {
-//        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
-//
-//        // modify here
-//        guard let currentItem = player.currentItem else { return }
-//        let durationInSeconds = CMTimeGetSeconds(currentItem.duration)
-//
-//        let elapsedTIme = CMTimeGetSeconds(player.currentTime())
-//
-//        nowPlayingInfo? [MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsedTIme
-//        nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = durationInSeconds
-//
-//        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-//    }
     
     fileprivate func updateCurrentTimeSlider() {
         let currentTimeSeconds = CMTimeGetSeconds(player.currentTime())
@@ -176,6 +159,24 @@ class PlayerDetailsView: UIView {
         }
     }
     
+    fileprivate func observeBoundaryTime() {
+        let time = CMTimeMake(value: 1, timescale: 3)
+        let times = [NSValue(time: time)]
+        player.addBoundaryTimeObserver(forTimes: times, queue: .main) {
+            [weak self] in
+            print("Episode started playing")
+            self?.enlargeEpisodeImageView()
+            self?.setupLockscreenDuration()
+        }
+    }
+    
+    fileprivate func setupLockscreenDuration() {
+        guard let duration = player.currentItem?.duration else { return }
+        let durationSeconds = CMTimeGetSeconds(duration )
+        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = durationSeconds
+        
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         
@@ -183,14 +184,7 @@ class PlayerDetailsView: UIView {
         setupAudioSession()
         setupGestures()
         observePlayerCurrentTime()
-        
-        let time = CMTimeMake(value: 1, timescale: 3)
-        let times = [NSValue(time: time)]
-        player.addBoundaryTimeObserver(forTimes: times, queue: .main) {
-            [weak self] in
-            print("Episode started playing")
-            self? .enlargeEpisodeImageView()
-        }
+        observeBoundaryTime()
     }
     
     @objc func handlePan(gesture: UIPanGestureRecognizer) {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -129,34 +129,31 @@ class PlayerDetailsView: UIView {
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
             self.player.play()
-            
             self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
-            
+            self.setupElapsedTime()
             return .success
         }
         
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
             self.player.pause()
-            
             self.playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
-
+            self.setupElapsedTime()
             return .success
         }
         
         commandCenter.togglePlayPauseCommand.isEnabled = true
         commandCenter.togglePlayPauseCommand.addTarget { (_) -> MPRemoteCommandHandlerStatus in
-            
             self.handlePlayPause()
-//            if self.player.timeControlStatus == .playing {
-//                self.player.pause()
-//            } else {
-//                self.player.play()
-//            }
             return .success
         }
+    }
+    
+    fileprivate func setupElapsedTime() {
+        let elapsedTime = CMTimeGetSeconds(player.currentTime())
+        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsedTime
     }
     
     fileprivate func observeBoundaryTime() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -19,7 +19,6 @@ class PlayerDetailsView: UIView {
             authorLabel.text = episode.author
             
             setUpNowPlayingInfo()
-            
             playEpisode()
             
             guard let url = URL(string: episode.imageUrl ?? "") else { return }
@@ -28,19 +27,17 @@ class PlayerDetailsView: UIView {
             
             miniEpisodeImageView.sd_setImage(with: url) { (image, _, _, _) in
                 
-                guard let image = image else{ return }
-                
-                // lockscreen image setup code
-                var nowPlayngInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo
-                
+               let image = self.episodeImageView.image ?? UIImage()
+//                // lockscreen image setup code
+//                var nowPlayngInfo = MPNowPlayingInfoCenter.default().nowPlayingInf
                 // some modifications here
-                let artwork = MPMediaItemArtwork(boundsSize: image.size, requestHandler: { (_) -> UIImage in
+                let artworkItem = MPMediaItemArtwork(boundsSize: .zero, requestHandler: { (size) -> UIImage in
                      return image
                 })
+                MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyArtwork] = artworkItem
                 
-                nowPlayngInfo?[MPMediaItemPropertyArtwork] = artwork
-
-                MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayngInfo
+//                nowPlayngInfo?[MPMediaItemPropertyArtwork] = artwork
+//                MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayngInfo
             }
         }
     }


### PR DESCRIPTION
Removed code for elapsed time and duration from playersDetailsView and instead set it up inside the awakeFromNib to avoid overriding the code for episode image on the lockscreen causing it not to display.
