### PR TITLE
Lesson8/handle interrupts

### DIFF
--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -223,12 +223,21 @@ class PlayerDetailsView: UIView {
         
     }
     
+    fileprivate func setupInterruptionObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleInterruption), name: .AVCaptureSessionInterruptionEnded, object: nil)
+    }
+    
+    @objc fileprivate func handleInterruption(notification: Notification) {
+        print("Interruption Observed...")
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         
         setupRemoteControl()
         setupAudioSession()
         setupGestures()
+        setupInterruptionObserver()
         observePlayerCurrentTime()
         observeBoundaryTime()
     }

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -229,6 +229,19 @@ class PlayerDetailsView: UIView {
     
     @objc fileprivate func handleInterruption(notification: Notification) {
         print("Interruption Observed...")
+        
+        guard let userInfo = notification.userInfo else { return }
+        guard let type =  userInfo[AVAudioSessionInterruptionTypeKey] as? UInt else { return }
+        
+        if type == AVAudioSession.InterruptionType.began.rawValue {
+            print("Interruption Began")
+
+        } else {
+            print("Interruption Ended")
+        }
+        
+        
+        
     }
     
     override func awakeFromNib() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -19,6 +19,8 @@ class PlayerDetailsView: UIView {
             authorLabel.text = episode.author
             
             setUpNowPlayingInfo()
+            
+            setupAudioSession()
             playEpisode()
             
             guard let url = URL(string: episode.imageUrl ?? "") else { return }
@@ -239,6 +241,7 @@ class PlayerDetailsView: UIView {
             miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
         } else {
             print("Interruption Ended")
+            
             player.play()
             playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
@@ -250,7 +253,6 @@ class PlayerDetailsView: UIView {
         super.awakeFromNib()
         
         setupRemoteControl()
-        setupAudioSession()
         setupGestures()
         setupInterruptionObserver()
         observePlayerCurrentTime()

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -133,11 +133,8 @@ class PlayerDetailsView: UIView {
             self.player.play()
             self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
-            self.setupElapsedTime()
-            
-            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 1
-            
-            return .success
+            self.setupElapsedTime(playbackRate: 1)
+             return .success
         }
         
         commandCenter.pauseCommand.isEnabled = true
@@ -145,10 +142,7 @@ class PlayerDetailsView: UIView {
             self.player.pause()
             self.playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
-            self.setupElapsedTime()
-            
-            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 0
-            
+            self.setupElapsedTime(playbackRate: 0)
             return .success
         }
         
@@ -208,9 +202,12 @@ class PlayerDetailsView: UIView {
         self.episode = nextEpisode
     }
     
-    fileprivate func setupElapsedTime() {
+    fileprivate func setupElapsedTime(playbackRate: Float) {
         let elapsedTime = CMTimeGetSeconds(player.currentTime())
         MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = elapsedTime
+        
+        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
+
     }
     
     fileprivate func observeBoundaryTime() {

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -235,12 +235,14 @@ class PlayerDetailsView: UIView {
         
         if type == AVAudioSession.InterruptionType.began.rawValue {
             print("Interruption Began")
-
+            playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
+            miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
         } else {
             print("Interruption Ended")
+            player.play()
+            playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
+            miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
         }
-        
-        
         
     }
     

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -134,6 +134,9 @@ class PlayerDetailsView: UIView {
             self.playPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             self.setupElapsedTime()
+            
+            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 1
+            
             return .success
         }
         
@@ -143,6 +146,9 @@ class PlayerDetailsView: UIView {
             self.playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             self.miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             self.setupElapsedTime()
+            
+            MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 0
+            
             return .success
         }
         

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -397,7 +397,7 @@ class PlayerDetailsView: UIView {
             miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             player.play()
             enlargeEpisodeImageView()
-            self.setupElapsedTime(playbackRate: 1) 
+            self.setupElapsedTime(playbackRate: 1)
         } else {
             playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)

--- a/Podcast/Podcast/Views/PlayerDetailsView.swift
+++ b/Podcast/Podcast/Views/PlayerDetailsView.swift
@@ -397,11 +397,13 @@ class PlayerDetailsView: UIView {
             miniPlayPauseButton.setImage(#imageLiteral(resourceName: "pause"), for: .normal)
             player.play()
             enlargeEpisodeImageView()
+            self.setupElapsedTime(playbackRate: 1) 
         } else {
             playPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             miniPlayPauseButton.setImage(#imageLiteral(resourceName: "play"), for: .normal)
             player.pause()
             shrinkEpisodeImageView()
+            self.setupElapsedTime(playbackRate: 0)
         }
     }
     


### PR DESCRIPTION
Setup a function to handle and monitor interrupts.
When the app is now able to monitor the interruptions, tell the app what to do.
When the interruption starts, the play/pause button will show PLAY. When the the interruption ended, the play/pause button will show PAUSe image.
Moved the setupAudioSession from awakeFromNib to  episode setup so that when something is playing from the background, the setupAudioSession will not interrupt and activate only when an episode was played.
Fixed the bug where the iOS still tracks the playback rate even when the play was paused.
